### PR TITLE
Fix compatibility with airwave gen1

### DIFF
--- a/airthings_ble/parser.py
+++ b/airthings_ble/parser.py
@@ -382,7 +382,8 @@ class AirthingsBluetoothDeviceData:
                     sensor_data = sensor_decoders[str(characteristic.uuid)](data)
                     # skip for now!
 
-                    sensor_data.pop("date_time")
+                    if "date_time" in sensor_data:
+                        sensor_data.pop("date_time")
 
                     device.sensors.update(sensor_data)
 


### PR DESCRIPTION
It seems like 'date_time' dict entry is not populated for v1 of the airwave, which causes _get_service_characteristics to throw an error. I'm not sure why this is the case or what the expectation is, but since the date_time entry is getting popped anyways, I figured that adding a condition guard is the quickest/easiest fix.

After this change I can import the sensor into home assistant, whereas prior to change adding the integration would fail with `[homeassistant.components.airthings_ble.config_flow] Unknown error occurred from CC:78:AB:15:75:02: 'date_time'`